### PR TITLE
bugfix for php 7.2 warning (test wrong also for other versions, but n…

### DIFF
--- a/WPPerformanceTester_Plugin.php
+++ b/WPPerformanceTester_Plugin.php
@@ -257,7 +257,7 @@ class WPPerformanceTester_Plugin extends WPPerformanceTester_LifeCycle {
         $options = $this->getOptionMetaData();
         if (!empty($options)) {
             foreach ($options as $key => $arr) {
-                if (is_array($arr) && count($arr > 1)) {
+                if (is_array($arr) && count($arr) > 1) {
                     $this->addOption($key, $arr[1]);
                 }
             }


### PR DESCRIPTION
Correct wrong test.

wp plugin install wpperformancetester --activate
Installing WPPerformanceTester (0.1)
Downloading installation package from https://downloads.wordpress.org/plugin/wpperformancetester.zip...
Unpacking the package...
Installing the plugin...
Plugin installed successfully.
Activating 'wpperformancetester'...
PHP Warning:  count(): Parameter must be an array or an object that implements Countable in public/wp-content/plugins/wpperformancetester/WPPerformanceTester_Plugin.php on line 260
...
Plugin 'wpperformancetester' activated.
