### PR TITLE
fix warnings

### DIFF
--- a/WPPerformanceTester_LifeCycle.php
+++ b/WPPerformanceTester_LifeCycle.php
@@ -148,7 +148,7 @@ class WPPerformanceTester_LifeCycle extends WPPerformanceTester_InstallIndicator
                          $displayName,
                          'manage_options',
                          $this->getSettingsSlug(),
-                         array(&$this, 'settingsPage'));
+                         array( $this, 'settingsPage'));
     }
 
     protected function addSettingsSubMenuPageToToolsMenu() {
@@ -159,7 +159,7 @@ class WPPerformanceTester_LifeCycle extends WPPerformanceTester_InstallIndicator
                          $displayName,
                          'manage_options',
                          $this->getSettingsSlug(),
-                         array(&$this, 'settingsPage'));
+                         array( $this, 'settingsPage'));
     }
 
 
@@ -170,7 +170,7 @@ class WPPerformanceTester_LifeCycle extends WPPerformanceTester_InstallIndicator
                          $displayName,
                          'manage_options',
                          $this->getSettingsSlug(),
-                         array(&$this, 'settingsPage'));
+                         array( $this, 'settingsPage'));
     }
 
     /**
@@ -190,9 +190,9 @@ class WPPerformanceTester_LifeCycle extends WPPerformanceTester_InstallIndicator
      * Convenience function for creating AJAX URLs.
      *
      * @param $actionName string the name of the ajax action registered in a call like
-     * add_action('wp_ajax_actionName', array(&$this, 'functionName'));
+     * add_action('wp_ajax_actionName', array($this, 'functionName'));
      *     and/or
-     * add_action('wp_ajax_nopriv_actionName', array(&$this, 'functionName'));
+     * add_action('wp_ajax_nopriv_actionName', array($this, 'functionName'));
      *
      * If have an additional parameters to add to the Ajax call, e.g. an "id" parameter,
      * you could call this function and append to the returned string like:

--- a/WPPerformanceTester_OptionsManager.php
+++ b/WPPerformanceTester_OptionsManager.php
@@ -241,15 +241,15 @@ class WPPerformanceTester_OptionsManager {
                       $pluginName,
                       'administrator',
                       get_class($this),
-                      array(&$this, 'settingsPage')
+                      array( $this, 'settingsPage' )
         /*,plugins_url('/images/icon.png', __FILE__)*/); // if you call 'plugins_url; be sure to "require_once" it
 
         //call register settings function
-        add_action('admin_init', array(&$this, 'registerSettings'));
+        add_action('admin_init', array( $this, 'registerSettings' ));
     }
 
     public function registerSettings() {
-        $settingsGroup = get_class($this) . '-settings-group';
+        $settingsGroup = get_class( $this ) . '-settings-group';
         $optionMetaData = $this->getOptionMetaData();
         foreach ($optionMetaData as $aOptionKey => $aOptionMeta) {
             register_setting($settingsGroup, $aOptionMeta);

--- a/WPPerformanceTester_Plugin.php
+++ b/WPPerformanceTester_Plugin.php
@@ -1,5 +1,5 @@
 <?php
-include_once( 'WPPerformanceTester_LifeCycle.php' );
+require_once( 'WPPerformanceTester_LifeCycle.php' );
 require_once( 'benchmark.php' );
 
 class WPPerformanceTester_Plugin extends WPPerformanceTester_LifeCycle {
@@ -340,43 +340,20 @@ class WPPerformanceTester_Plugin extends WPPerformanceTester_LifeCycle {
     }
 
     public function enqueue_scripts_and_style( $hook ) {
-      if ( strpos( $_SERVER['REQUEST_URI'], $this->getSettingsSlug() ) !== false ) {
-          wp_enqueue_script( 'chart-js', plugins_url('/js/Chart.js', __FILE__) );
-          wp_enqueue_script( 'jquery');
-          wp_enqueue_style( 'wppt-style', plugins_url('/css/wppt.css', __FILE__) );
-          wp_enqueue_style( 'simptip-style', plugins_url('/css/simptip.css', __FILE__) );
-      }
+        if ( $hook != 'tools_page_WPPerformanceTester_PluginSettings' ) {
+            return;
+        }
+        wp_enqueue_script( 'chart-js', plugins_url('/js/Chart.js', __FILE__) );
+        wp_enqueue_script( 'jquery');
+        wp_enqueue_style( 'wppt-style', plugins_url('/css/wppt.css', __FILE__) );
+        wp_enqueue_style( 'simptip-style', plugins_url('/css/simptip.css', __FILE__) );
     }
 
     public function addActionsAndFilters() {
 
         // Add options administration page
         // http://plugin.michael-simpson.com/?page_id=47
-        add_action('admin_menu', array(&$this, 'addSettingsSubMenuPage'));
-
+        add_action('admin_menu', array( $this, 'addSettingsSubMenuPage'));
         add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts_and_style' ) );
-
-
-        // Add Actions & Filters
-        // http://plugin.michael-simpson.com/?page_id=37
-
-
-        // Adding scripts & styles to all pages
-        // Examples:
-        //        wp_enqueue_script('jquery');
-        //        wp_enqueue_style('my-style', plugins_url('/css/my-style.css', __FILE__));
-        //        wp_enqueue_script('my-script', plugins_url('/js/my-script.js', __FILE__));
-
-
-        // Register short codes
-        // http://plugin.michael-simpson.com/?page_id=39
-
-
-        // Register AJAX hooks
-        // http://plugin.michael-simpson.com/?page_id=41
-
     }
-
-
 }
-

--- a/WPPerformanceTester_Plugin.php
+++ b/WPPerformanceTester_Plugin.php
@@ -12,7 +12,7 @@ class WPPerformanceTester_Plugin extends WPPerformanceTester_LifeCycle {
             wp_die(__('You do not have sufficient permissions to access this page.', 'TEXT-DOMAIN'));
         }
         $performTest = false;
-        if ($_POST['performTest'] == true){
+        if ( !empty( $_POST['performTest'] ) && ( $_POST['performTest'] == true ) ) {
             $performTest=true;
         }
         ?>
@@ -20,13 +20,13 @@ class WPPerformanceTester_Plugin extends WPPerformanceTester_LifeCycle {
             <h2>WPPerformanceTester</h2>
             <p>WPPerformanceTester performs a series of tests to see how well your server performs. The first set test the raw server performance. The second is WordPress specific. Your results will be displayed and you can see how your results stack up against others.</p>
 
-            <form method="post" action="<?php echo admin_url('tools.php?page=WPPerformanceTester_PluginSettings'); ?>">
+            <form method="post" action="<?php echo esc_url( admin_url('tools.php?page=WPPerformanceTester_PluginSettings') ); ?>">
                 <input type="hidden" name="performTest" value="true">
                 <input type="submit" value="Begin Performance Test" onclick="this.value='This may take a minute...'">
             </form>
 
             <?php
-            if ($performTest){
+            if ( $performTest ) {
                 //do test
                 global $wpdb;
                 $arr_cfg = array();

--- a/WPPerformanceTester_Plugin.php
+++ b/WPPerformanceTester_Plugin.php
@@ -1,6 +1,7 @@
 <?php
-include_once('WPPerformanceTester_LifeCycle.php');
-require_once('benchmark.php');
+include_once( 'WPPerformanceTester_LifeCycle.php' );
+require_once( 'benchmark.php' );
+
 class WPPerformanceTester_Plugin extends WPPerformanceTester_LifeCycle {
 
     /**
@@ -9,7 +10,7 @@ class WPPerformanceTester_Plugin extends WPPerformanceTester_LifeCycle {
     public function settingsPage() {
 
         if (!current_user_can('manage_options')) {
-            wp_die(__('You do not have sufficient permissions to access this page.', 'TEXT-DOMAIN'));
+            wp_die(__('You do not have sufficient permissions to access this page.'));
         }
         $performTest = false;
         if ( !empty( $_POST['performTest'] ) && ( $_POST['performTest'] == true ) ) {
@@ -338,20 +339,22 @@ class WPPerformanceTester_Plugin extends WPPerformanceTester_LifeCycle {
     public function upgrade() {
     }
 
+    public function enqueue_scripts_and_style( $hook ) {
+      if ( strpos( $_SERVER['REQUEST_URI'], $this->getSettingsSlug() ) !== false ) {
+          wp_enqueue_script( 'chart-js', plugins_url('/js/Chart.js', __FILE__) );
+          wp_enqueue_script( 'jquery');
+          wp_enqueue_style( 'wppt-style', plugins_url('/css/wppt.css', __FILE__) );
+          wp_enqueue_style( 'simptip-style', plugins_url('/css/simptip.css', __FILE__) );
+      }
+    }
+
     public function addActionsAndFilters() {
 
         // Add options administration page
         // http://plugin.michael-simpson.com/?page_id=47
         add_action('admin_menu', array(&$this, 'addSettingsSubMenuPage'));
 
-        // Example adding a script & style just for the options administration page
-        // http://plugin.michael-simpson.com/?page_id=47
-                if (strpos($_SERVER['REQUEST_URI'], $this->getSettingsSlug()) !== false) {
-                    wp_enqueue_script('chart-js', plugins_url('/js/Chart.js', __FILE__));
-                    wp_enqueue_script('jquery');
-                    wp_enqueue_style('wppt-style', plugins_url('/css/wppt.css', __FILE__));
-                    wp_enqueue_style('simptip-style', plugins_url('/css/simptip.css', __FILE__));
-                }
+        add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts_and_style' ) );
 
 
         // Add Actions & Filters

--- a/wp-performance-tester.php
+++ b/wp-performance-tester.php
@@ -39,9 +39,9 @@ $WPPerformanceTester_minimalRequiredPhpVersion = '5.0';
 function WPPerformanceTester_noticePhpVersionWrong() {
     global $WPPerformanceTester_minimalRequiredPhpVersion;
     echo '<div class="updated fade">' .
-      __('Error: plugin "WP Performance Tester" requires a newer version of PHP to be running.',  'wp-performance-tester').
-            '<br/>' . __('Minimal version of PHP required: ', 'wp-performance-tester') . '<strong>' . $WPPerformanceTester_minimalRequiredPhpVersion . '</strong>' .
-            '<br/>' . __('Your server\'s PHP version: ', 'wp-performance-tester') . '<strong>' . phpversion() . '</strong>' .
+      esc_html__('Error: plugin "WP Performance Tester" requires a newer version of PHP to be running.',  'wp-performance-tester').
+            '<br/>' . esc_html__('Minimal version of PHP required: ', 'wp-performance-tester') . '<strong>' . esc_html( $WPPerformanceTester_minimalRequiredPhpVersion ) . '</strong>' .
+            '<br/>' . esc_html__('Your server\'s PHP version: ', 'wp-performance-tester') . '<strong>' . esc_html( phpversion() ) . '</strong>' .
          '</div>';
 }
 
@@ -79,8 +79,8 @@ WPPerformanceTester_i18n_init();
 
 // Next, run the version check.
 // If it is successful, continue with initialization for this plugin
-if (WPPerformanceTester_PhpVersionCheck()) {
+if ( WPPerformanceTester_PhpVersionCheck() ) {
     // Only load and run the init function if we know PHP version can parse it
-    include_once('wp-performance-tester_init.php');
-    WPPerformanceTester_init(__FILE__);
+    require_once( 'wp-performance-tester_init.php' );
+    WPPerformanceTester_init( __FILE__ );
 }

--- a/wp-performance-tester_init.php
+++ b/wp-performance-tester_init.php
@@ -45,9 +45,9 @@ function WPPerformanceTester_init($file) {
         $file = __FILE__;
     }
     // Register the Plugin Activation Hook
-    register_activation_hook($file, array(&$aPlugin, 'activate'));
+    register_activation_hook($file, array( $aPlugin, 'activate'));
 
 
     // Register the Plugin Deactivation Hook
-    register_deactivation_hook($file, array(&$aPlugin, 'deactivate'));
+    register_deactivation_hook($file, array( $aPlugin, 'deactivate'));
 }


### PR DESCRIPTION
This adds:

 - some escaping
 - removes the PHP4 action hooks, we don't need to do `array( &$this...` we can just do `array( $this`
 - Fixes a PHP warning on the tools page for an undefined offset
 - Fixes the way that the scripts and styles are enqueued so that they're only enqueued on the correct hook
 - Use the parameters from the hook used in the previous fix to conditionally load the styles rather than looking at the `$_SERVER` global